### PR TITLE
[fix] #85 보안 관련 업데이트 및 exception 처리 추가

### DIFF
--- a/docs/dev-setup-windows-mac.md
+++ b/docs/dev-setup-windows-mac.md
@@ -1,0 +1,222 @@
+# Development Setup For Windows And Mac
+
+## 목적
+
+이 문서는 팀원이 GitHub에서 최신 프로젝트를 받은 뒤 Windows 또는 Mac 환경에서 로컬 실행을 위해 필요한 최소 세팅을 정리한 문서입니다.
+
+## 공통 준비 사항
+
+### 1. 프로젝트 받기
+
+```bash
+git clone <repository-url>
+cd AIBE5-Project2_Team13
+```
+
+이미 프로젝트를 받은 상태라면 최신 코드로 갱신합니다.
+
+```bash
+git checkout develop
+git pull origin develop
+```
+
+### 2. 필수 도구
+
+- Java 17 JDK
+- Node.js + npm
+- Git
+- IntelliJ IDEA 또는 VS Code
+
+주의:
+
+- JRE만 있으면 테스트/빌드가 되지 않습니다.
+- 반드시 JDK가 설치되어 있어야 합니다.
+
+### 3. 확인할 설정 파일
+
+백엔드는 아래 설정을 사용합니다.
+
+- `src/main/resources/application.properties`
+- `src/main/resources/application-secret.properties`
+- `src/main/resources/application-test.properties`
+
+팀 내에서 민감정보 관리 정책상 `application-secret.properties` 내용을 별도로 전달받아야 하는 경우, 최신 내용을 팀 저장소 또는 팀장이 공유한 값으로 맞춰야 합니다.
+
+## Windows 설정
+
+### 1. JDK 확인
+
+PowerShell:
+
+```powershell
+java -version
+javac -version
+```
+
+`javac`가 정상 출력되어야 합니다.
+
+### 2. 백엔드 파일 저장 폴더 생성
+
+현재 기본 설정은 Windows 경로 기준입니다.
+
+```properties
+file.upload.path=D:\\fileDownLoadServer\\
+```
+
+따라서 로컬 PC에 아래 폴더를 생성합니다.
+
+```powershell
+mkdir D:\fileDownLoadServer
+```
+
+### 3. 백엔드 실행
+
+PowerShell:
+
+```powershell
+.\mvnw.cmd spring-boot:run
+```
+
+테스트 실행:
+
+```powershell
+.\mvnw.cmd test
+```
+
+### 4. 프론트엔드 실행
+
+```powershell
+cd frontend
+npm install
+npm run dev
+```
+
+## Mac 설정
+
+### 1. JDK 확인
+
+Terminal:
+
+```bash
+java -version
+javac -version
+```
+
+`javac`가 없으면 JDK를 다시 설치해야 합니다.
+
+### 2. 파일 저장 경로 수정
+
+현재 기본값은 Windows 경로라서 Mac에서는 그대로 사용할 수 없습니다.
+
+Mac 사용자는 로컬 실행 전에 `file.upload.path`를 Mac 경로로 바꿔야 합니다.
+
+예시:
+
+```properties
+file.upload.path=/Users/{mac-user}/fileDownLoadServer/
+```
+
+또는 프로젝트 바깥 공통 폴더를 하나 정해서 사용해도 됩니다.
+
+예:
+
+```properties
+file.upload.path=/Users/{mac-user}/dev/fileDownLoadServer/
+```
+
+### 3. Mac 로컬 폴더 생성
+
+```bash
+mkdir -p /Users/{mac-user}/fileDownLoadServer
+```
+
+### 4. 권장 방식
+
+Mac 사용자는 `application-secret.properties`를 직접 수정하기보다, 로컬 환경 전용 설정 파일이나 실행 환경 변수로 오버라이드하는 방식을 권장합니다.
+
+예:
+
+```bash
+./mvnw spring-boot:run -Dspring-boot.run.arguments="--file.upload.path=/Users/{mac-user}/fileDownLoadServer/"
+```
+
+또는 IntelliJ 실행 구성에서 아래 VM 옵션 또는 프로그램 인자를 추가합니다.
+
+```text
+--file.upload.path=/Users/{mac-user}/fileDownLoadServer/
+```
+
+### 5. 백엔드 실행
+
+```bash
+./mvnw spring-boot:run
+```
+
+테스트 실행:
+
+```bash
+./mvnw test
+```
+
+### 6. 프론트엔드 실행
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## 파일 업로드 모듈 관련 환경 체크
+
+Windows와 Mac 모두 아래를 꼭 확인합니다.
+
+### 1. 업로드 폴더가 실제로 존재하는지
+
+`file.upload.path`에 지정한 폴더가 실제로 있어야 합니다.
+
+### 2. 서버가 해당 경로에 쓰기 가능한지
+
+업로드는 서버가 파일을 직접 저장하므로 쓰기 권한이 있어야 합니다.
+
+### 3. 응답의 `fileUrl` 의미
+
+응답 `fileUrl`은 디스크 경로가 아니라 다운로드 API 경로입니다.
+
+예:
+
+```text
+/api/files/download/uuid-file-name.png
+```
+
+즉, 프론트는 `fileUrl`을 그대로 사용하면 되고, 실제 저장은 `file.upload.path` 아래에서 처리됩니다.
+
+## 문제 발생 시 우선 점검 항목
+
+### `No compiler is provided in this environment`
+
+- 원인: JRE만 설치됨
+- 해결: JDK 17 설치 후 `javac -version` 확인
+
+### 업로드는 되는데 파일이 안 보임
+
+- `fileUrl`을 화면에서 제대로 사용했는지 확인
+- `/api/files/download/{savedFileName}` 호출이 가능한지 확인
+- `file.upload.path` 폴더에 실제 파일이 생성됐는지 확인
+
+### Mac에서 업로드가 안 됨
+
+- Windows 경로가 그대로 남아 있는지 확인
+- `/Users/...` 형태로 `file.upload.path`를 수정했는지 확인
+- 해당 폴더에 쓰기 권한이 있는지 확인
+
+## 팀원 공유용 짧은 안내문
+
+```md
+GitHub 최신 코드 받은 뒤 아래만 확인해주세요.
+
+- Java는 JDK 17이어야 합니다. `javac -version` 확인
+- Windows는 `D:\fileDownLoadServer` 폴더 생성
+- Mac은 `file.upload.path`를 본인 Mac 경로로 변경
+- 프론트 실행 전 `frontend`에서 `npm install`
+- 백엔드 실행은 루트에서 `mvnw` 또는 `mvnw.cmd` 사용
+```

--- a/docs/file-upload-module-guide.md
+++ b/docs/file-upload-module-guide.md
@@ -1,0 +1,182 @@
+# File Upload Module Guide
+
+## 목적
+
+이 문서는 팀원들이 공통 파일 업로드 모듈을 중복 구현 없이 바로 사용할 수 있도록 정리한 가이드입니다.
+
+이 모듈은 다음 대상의 첨부파일을 공통 처리합니다.
+
+- `CLASS`
+- `MEMBER`
+- `FREELANCER`
+
+각 도메인에서 파일 저장 로직을 별도로 만들지 말고, 반드시 공통 `FileService` 또는 `/api/files` API를 사용합니다.
+
+## 공통 규칙
+
+### 1. 필수 파라미터
+
+업로드/수정 시 아래 두 값은 반드시 함께 전달합니다.
+
+- `targetType`: `CLASS` | `MEMBER` | `FREELANCER`
+- `targetId`: 각 대상 엔티티의 PK
+
+예시:
+
+- `CLASS` -> 클래스 ID
+- `MEMBER` -> 회원 ID
+- `FREELANCER` -> 프리랜서 프로필 ID
+
+### 2. 반환값 의미
+
+업로드 응답의 `fileUrl`은 로컬 디스크 경로가 아닙니다.
+
+`fileUrl`은 프론트에서 바로 접근 가능한 다운로드 API 경로입니다.
+
+예:
+
+```json
+{
+  "fileId": 15,
+  "originalFileName": "thumbnail.png",
+  "fileUrl": "/api/files/download/550e8400-e29b-41d4-a716-446655440000.png",
+  "fileSize": 32145
+}
+```
+
+### 3. 실제 저장 위치
+
+실제 파일은 서버 로컬 경로인 `file.upload.path` 아래에 저장됩니다.
+
+현재 기본 설정 예시:
+
+```properties
+file.upload.path=D:\\fileDownLoadServer\\
+```
+
+다운로드 API는 위 경로에 저장된 실제 파일을 읽어서 내려줍니다.
+
+삭제 API는 DB 레코드 삭제 후 해당 실제 파일도 함께 삭제합니다.
+
+## API 목록
+
+### 단건 업로드
+
+- Method: `POST`
+- URL: `/api/files/upload`
+
+폼데이터:
+
+- `file`
+- `targetType`
+- `targetId`
+
+### 다건 업로드
+
+- Method: `POST`
+- URL: `/api/files/upload/multiple`
+
+폼데이터:
+
+- `files`
+- `targetType`
+- `targetId`
+
+### 파일 수정
+
+- Method: `PUT`
+- URL: `/api/files/{fileId}`
+
+폼데이터:
+
+- `file`
+- `targetType`
+- `targetId`
+
+### 파일 삭제
+
+- Method: `DELETE`
+- URL: `/api/files/{fileId}`
+
+쿼리 파라미터:
+
+- `targetType`
+
+### 파일 다운로드
+
+- Method: `GET`
+- URL: `/api/files/download/{savedFileName}`
+
+## 백엔드에서 직접 사용하는 방법
+
+다른 서비스에서 파일 업로드가 필요하면 `FileService`를 주입받아 사용합니다.
+
+```java
+private final FileService fileService;
+```
+
+### 단건 업로드 예시
+
+```java
+FileUploadResponse response =
+        fileService.upload(file, FileTargetType.CLASS, classId);
+```
+
+### 다건 업로드 예시
+
+```java
+List<FileUploadResponse> responseList =
+        fileService.uploadMultiple(files, FileTargetType.CLASS, classId);
+```
+
+### 응답 활용 예시
+
+```java
+FileUploadResponse response =
+        fileService.upload(file, FileTargetType.MEMBER, memberId);
+
+String imageUrl = response.getFileUrl();
+Long fileId = response.getFileId();
+```
+
+## 프론트엔드 사용 예시
+
+```javascript
+const formData = new FormData();
+formData.append("file", file);
+
+const response = await axios.post(
+  "/api/files/upload?targetType=MEMBER&targetId=1",
+  formData
+);
+
+const { fileId, fileUrl } = response.data;
+```
+
+이미지 출력 예시:
+
+```javascript
+<img src={fileUrl} alt="profile" />
+```
+
+## 사용 시 주의사항
+
+- 각 도메인에서 `MultipartFile.transferTo()`를 직접 호출하지 않습니다.
+- 각 도메인에서 임의의 로컬 경로에 파일을 저장하지 않습니다.
+- 업로드 후에는 응답의 `fileUrl`을 화면 표시용으로 사용합니다.
+- 삭제는 소프트 삭제가 아니라 실제 DB 레코드 삭제 + 물리 파일 삭제입니다.
+- 다건 업로드는 일부 파일 실패 시 실패한 파일만 건너뛰고 나머지를 계속 처리합니다.
+
+## 팀 공지용 짧은 안내문
+
+아래 문구를 팀 채팅방이나 PR 설명에 그대로 공유해도 됩니다.
+
+```md
+파일 업로드는 공통 모듈만 사용해주세요.
+
+- API 경로: `/api/files/**`
+- 필수값: `targetType`, `targetId`
+- 응답 `fileUrl`은 프론트에서 바로 사용할 수 있는 다운로드 API 경로입니다
+- 각 도메인에서 개별 파일 저장 로직은 추가하지 않습니다
+- 삭제는 DB 레코드 + 실제 파일이 함께 삭제됩니다
+```

--- a/src/main/java/com/ilsamcheonri/hobby/controller/FileController.java
+++ b/src/main/java/com/ilsamcheonri/hobby/controller/FileController.java
@@ -21,7 +21,7 @@ import java.util.List;
  * ── 단일 파일 API ────────────────────────────────────────────
  * POST   /api/files/upload                파일 단건 등록
  * PUT    /api/files/{fileId}              파일 수정 (기존 삭제 + 새 파일 등록)
- * DELETE /api/files/{fileId}              파일 삭제 (DB 소프트 삭제 + 실제 파일 삭제)
+ * DELETE /api/files/{fileId}              파일 삭제 (DB 레코드 삭제 + 실제 파일 삭제)
  * GET    /api/files/download/{fileName}   파일 다운로드
  *
  * ── 다중 파일 API ────────────────────────────────────────────
@@ -101,7 +101,7 @@ public class FileController {
     // ✅ 파일 단건 삭제
     // DELETE /api/files/{fileId}?targetType=CLASS
     //
-    // DB 소프트 삭제 + 실제 파일 삭제를 함께 처리합니다.
+     // DB 레코드 삭제 + 실제 파일 삭제를 함께 처리합니다.
     // =========================================================
     @DeleteMapping("/{fileId}")
     public ResponseEntity<Void> delete(
@@ -155,6 +155,9 @@ public class FileController {
         } catch (IllegalArgumentException e) {
             // 파일이 없는 경우 404 응답
             return ResponseEntity.notFound().build();
+        } catch (SecurityException e) {
+            // 잘못된 경로 접근 시 400 응답
+            return ResponseEntity.badRequest().build();
         }
     }
 }

--- a/src/main/java/com/ilsamcheonri/hobby/dto/file/FileUploadResponse.java
+++ b/src/main/java/com/ilsamcheonri/hobby/dto/file/FileUploadResponse.java
@@ -8,7 +8,7 @@ import lombok.Getter;
  *
  * fileId          : 저장된 첨부파일 고유번호 (수정/삭제 시 사용)
  * originalFileName: 사용자가 올린 원본 파일명
- * fileUrl         : 파일 접근 경로 (프론트에서 이미지 표시에 사용)
+ * fileUrl         : 파일 접근 API 경로 (프론트에서 이미지 표시에 사용)
  * fileSize        : 파일 용량 (Byte)
  */
 @Getter

--- a/src/main/java/com/ilsamcheonri/hobby/service/FileService.java
+++ b/src/main/java/com/ilsamcheonri/hobby/service/FileService.java
@@ -10,6 +10,7 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -34,7 +35,7 @@ import java.util.UUID;
  */
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class FileService {
 
     private final ClassAttachmentRepository             classAttachmentRepository;
@@ -53,8 +54,10 @@ public class FileService {
     // ✅ 1. 파일 단건 업로드
     // =========================================================
 
+    private static final String DOWNLOAD_URL_PREFIX = "/api/files/download/";
+
     /**
-     * 파일을 D:\fileDownLoadServer\에 저장하고 해당 첨부파일 테이블에 기록합니다.
+      * 파일을 D:\fileDownLoadServer\에 저장하고 해당 첨부파일 테이블에 기록합니다.
      *
      * [수정 - 문제 1, 3]
      * 기존: ClassBoard.builder().id(classId).build() 방식 (프록시 — 존재 확인 없음)
@@ -67,20 +70,33 @@ public class FileService {
             Long targetId
     ) throws IOException {
 
-        String originalFileName = file.getOriginalFilename();
-        String savedFileName    = UUID.randomUUID() + "_" + originalFileName;
-        String fileUrl          = uploadPath + savedFileName;
-        long   fileSize         = file.getSize();
+        // 1. 경로 조작 방지를 위한 파일명 정제
+        String originalFileName = StringUtils.cleanPath(file.getOriginalFilename());
+        if (originalFileName.contains("..")) {
+            throw new SecurityException("잘못된 파일명입니다.");
+        }
 
-        Path savePath = Paths.get(fileUrl);
-        Files.createDirectories(savePath.getParent());
-        file.transferTo(savePath.toFile());
+        // 2. 확장자 추출 및 안전한 랜덤 파일명 생성
+        String extension = "";
+        int dotIndex = originalFileName.lastIndexOf('.');
+        if (dotIndex > 0) {
+            extension = originalFileName.substring(dotIndex);
+        }
+        String savedFileName = UUID.randomUUID().toString() + extension;
+        String fileUrl = DOWNLOAD_URL_PREFIX + savedFileName;
+        long fileSize = file.getSize();
 
+        // 3. DB 존재 검증 및 정보 저장을 먼저 수행 (예외 발생 시 여기서 중단, 파일 저장소 누수 방지)
         Long savedId = switch (targetType) {
             case CLASS      -> uploadClassAttachment(targetId, originalFileName, savedFileName, fileUrl, fileSize);
             case MEMBER     -> uploadMemberAttachment(targetId, originalFileName, savedFileName, fileUrl, fileSize);
             case FREELANCER -> uploadFreelancerAttachment(targetId, originalFileName, savedFileName, fileUrl, fileSize);
         };
+
+        // 4. DB 저장이 성공한 경우에만 실제 물리적 파일 저장
+        Path savePath = Paths.get(uploadPath).resolve(savedFileName).normalize();
+        Files.createDirectories(savePath.getParent());
+        file.transferTo(savePath.toFile());
 
         return FileUploadResponse.builder()
                 .fileId(savedId)
@@ -109,7 +125,7 @@ public class FileService {
             if (file.isEmpty()) continue;
             try {
                 results.add(upload(file, targetType, targetId));
-            } catch (IOException e) {
+            } catch (Exception e) {
                 System.err.println("[FileService] 파일 업로드 실패: "
                         + file.getOriginalFilename() + " / " + e.getMessage());
             }
@@ -151,34 +167,34 @@ public class FileService {
     }
 
     // =========================================================
-    // ✅ 4. 파일 단건 삭제 (DB 소프트 삭제 + 실제 파일 삭제)
+     // ✅ 4. 파일 단건 삭제 (DB 레코드 삭제 + 실제 파일 삭제)
     // =========================================================
 
     /**
-     * DB is_deleted = true 처리 + D:\fileDownLoadServer\에서 실제 파일 삭제를 함께 처리합니다.
+     * DB 레코드 삭제 + D:\fileDownLoadServer\에서 실제 파일 삭제를 함께 처리합니다.
      */
     public void delete(Long fileId, FileTargetType targetType) {
 
         String savedFileName = switch (targetType) {
             case CLASS -> {
                 ClassAttachment a = classAttachmentRepository
-                        .findByIdAndIsDeletedFalse(fileId)
+                        .findById(fileId)
                         .orElseThrow(() -> new IllegalArgumentException("파일을 찾을 수 없습니다. fileId: " + fileId));
-                a.softDelete();
+                classAttachmentRepository.delete(a);
                 yield a.getSavedFileName();
             }
             case MEMBER -> {
                 MemberAttachment a = memberAttachmentRepository
-                        .findByIdAndIsDeletedFalse(fileId)
+                        .findById(fileId)
                         .orElseThrow(() -> new IllegalArgumentException("파일을 찾을 수 없습니다. fileId: " + fileId));
-                a.softDelete();
+                memberAttachmentRepository.delete(a);
                 yield a.getSavedFileName();
             }
             case FREELANCER -> {
                 FreelancerProfileAttachment a = freelancerAttachmentRepository
-                        .findByIdAndIsDeletedFalse(fileId)
+                        .findById(fileId)
                         .orElseThrow(() -> new IllegalArgumentException("파일을 찾을 수 없습니다. fileId: " + fileId));
-                a.softDelete();
+                freelancerAttachmentRepository.delete(a);
                 yield a.getSavedFileName();
             }
         };
@@ -220,12 +236,18 @@ public class FileService {
      */
     @Transactional(readOnly = true)
     public Resource download(String savedFileName) {
-        Path filePath = Paths.get(uploadPath + savedFileName);
+        String cleanFileName = StringUtils.cleanPath(savedFileName);
+
+        if (cleanFileName.contains("..")) {
+            throw new SecurityException("잘못된 파일 경로입니다.");
+        }
+
+        Path filePath = Paths.get(uploadPath).resolve(cleanFileName).normalize();
         Resource resource = new FileSystemResource(filePath);
 
         if (!resource.exists()) {
             throw new IllegalArgumentException(
-                "파일을 찾을 수 없습니다. 이미 삭제되었거나 경로가 올바르지 않습니다: " + savedFileName
+                "파일을 찾을 수 없습니다. 이미 삭제되었거나 경로가 올바르지 않습니다: " + cleanFileName
             );
         }
         return resource;

--- a/src/test/java/com/ilsamcheonri/hobby/controller/FileControllerTest.java
+++ b/src/test/java/com/ilsamcheonri/hobby/controller/FileControllerTest.java
@@ -1,0 +1,191 @@
+package com.ilsamcheonri.hobby.controller;
+
+import com.ilsamcheonri.hobby.HobbyMatchingApplication;
+import com.ilsamcheonri.hobby.dto.file.FileUploadResponse;
+import com.ilsamcheonri.hobby.enums.FileTargetType;
+import com.ilsamcheonri.hobby.service.FileService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(classes = HobbyMatchingApplication.class)
+@AutoConfigureMockMvc
+@TestPropertySource(
+        locations = "classpath:application-test.properties",
+        properties = "jwt.secret=IlsamcheonriTeamHobbyMatchingProjectSecretKey2026!@#"
+)
+class FileControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private FileService fileService;
+
+    @Test
+    @DisplayName("파일 단건 업로드 성공 시 201과 응답 DTO를 반환한다.")
+    @WithMockUser(username = "tester")
+    void upload_success() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "profile.png",
+                MediaType.IMAGE_PNG_VALUE,
+                "image-content".getBytes(StandardCharsets.UTF_8)
+        );
+
+        FileUploadResponse response = FileUploadResponse.builder()
+                .fileId(1L)
+                .originalFileName("profile.png")
+                .fileUrl("/api/files/download/test-image.png")
+                .fileSize(13L)
+                .build();
+
+        when(fileService.upload(any(), eq(FileTargetType.MEMBER), eq(10L))).thenReturn(response);
+
+        mockMvc.perform(multipart("/api/files/upload")
+                        .file(file)
+                        .param("targetType", "MEMBER")
+                        .param("targetId", "10"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.fileId").value(1L))
+                .andExpect(jsonPath("$.originalFileName").value("profile.png"))
+                .andExpect(jsonPath("$.fileUrl").value("/api/files/download/test-image.png"))
+                .andExpect(jsonPath("$.fileSize").value(13L));
+    }
+
+    @Test
+    @DisplayName("파일 다건 업로드 성공 시 201과 목록을 반환한다.")
+    @WithMockUser(username = "tester")
+    void uploadMultiple_success() throws Exception {
+        MockMultipartFile file1 = new MockMultipartFile(
+                "files",
+                "a.png",
+                MediaType.IMAGE_PNG_VALUE,
+                "a".getBytes(StandardCharsets.UTF_8)
+        );
+        MockMultipartFile file2 = new MockMultipartFile(
+                "files",
+                "b.png",
+                MediaType.IMAGE_PNG_VALUE,
+                "b".getBytes(StandardCharsets.UTF_8)
+        );
+
+        List<FileUploadResponse> response = List.of(
+                FileUploadResponse.builder()
+                        .fileId(1L)
+                        .originalFileName("a.png")
+                        .fileUrl("/api/files/download/a-saved.png")
+                        .fileSize(1L)
+                        .build(),
+                FileUploadResponse.builder()
+                        .fileId(2L)
+                        .originalFileName("b.png")
+                        .fileUrl("/api/files/download/b-saved.png")
+                        .fileSize(1L)
+                        .build()
+        );
+
+        when(fileService.uploadMultiple(any(), eq(FileTargetType.CLASS), eq(3L))).thenReturn(response);
+
+        mockMvc.perform(multipart("/api/files/upload/multiple")
+                        .file(file1)
+                        .file(file2)
+                        .param("targetType", "CLASS")
+                        .param("targetId", "3"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$[0].fileId").value(1L))
+                .andExpect(jsonPath("$[0].fileUrl").value("/api/files/download/a-saved.png"))
+                .andExpect(jsonPath("$[1].fileId").value(2L))
+                .andExpect(jsonPath("$[1].fileUrl").value("/api/files/download/b-saved.png"));
+    }
+
+    @Test
+    @DisplayName("파일 수정 성공 시 200과 새 파일 정보를 반환한다.")
+    @WithMockUser(username = "tester")
+    void update_success() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "changed.png",
+                MediaType.IMAGE_PNG_VALUE,
+                "changed".getBytes(StandardCharsets.UTF_8)
+        );
+
+        FileUploadResponse response = FileUploadResponse.builder()
+                .fileId(9L)
+                .originalFileName("changed.png")
+                .fileUrl("/api/files/download/changed-saved.png")
+                .fileSize(7L)
+                .build();
+
+        when(fileService.update(eq(7L), any(), eq(FileTargetType.FREELANCER), eq(2L))).thenReturn(response);
+
+        mockMvc.perform(multipart("/api/files/7")
+                        .file(file)
+                        .with(request -> {
+                            request.setMethod("PUT");
+                            return request;
+                        })
+                        .param("targetType", "FREELANCER")
+                        .param("targetId", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.fileId").value(9L))
+                .andExpect(jsonPath("$.fileUrl").value("/api/files/download/changed-saved.png"));
+    }
+
+    @Test
+    @DisplayName("파일 단건 삭제 성공 시 204를 반환한다.")
+    @WithMockUser(username = "tester")
+    void delete_success() throws Exception {
+        doNothing().when(fileService).delete(5L, FileTargetType.CLASS);
+
+        mockMvc.perform(delete("/api/files/5")
+                        .param("targetType", "CLASS"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("파일 다운로드 성공 시 200과 파일 바디를 반환한다.")
+    void download_success() throws Exception {
+        ByteArrayResource resource = new ByteArrayResource("hello-file".getBytes(StandardCharsets.UTF_8)) {
+            @Override
+            public boolean exists() {
+                return true;
+            }
+        };
+
+        when(fileService.download("sample.png")).thenReturn(resource);
+
+        mockMvc.perform(get("/api/files/download/sample.png"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Disposition", "attachment; filename=\"sample.png\""))
+                .andExpect(content().bytes("hello-file".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    @DisplayName("파일이 없으면 다운로드 API는 404를 반환한다.")
+    void download_notFound() throws Exception {
+        doThrow(new IllegalArgumentException("파일 없음"))
+                .when(fileService).download("missing.png");
+
+        mockMvc.perform(get("/api/files/download/missing.png"))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
url을 이용하여 프론트엔드에서도 접속할 수 있도록 수정

## 🔎 What

- 파일 업로드 로직 수정 및 프론트엔드에서도 사용할 수 있게 수정 
- 파일 업로드 관련하여 세팅 md 파일 추가

## 🔗 Issue

- Closes: #85 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?
