### PR TITLE
[Bug] 메인화면에 진행중인 클래스만 뜨게 수정

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -115,7 +115,8 @@ export default function Home() {
             </Link>
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
-            {classes.slice(0, 8).map((item) => (
+            {/* 모집중인 클래스(status === 'OPEN')만 필터링하여 상위 8개 노출 */}
+            {classes.filter(item => item.status === 'OPEN').slice(0, 8).map((item) => (
               <ClassCard key={item.id} item={item} />
             ))}
           </div>


### PR DESCRIPTION
## 🔎 What

- 메인화면에 모집중인 클래스만 노출되도록 수정

## 🔗 Issue

- Closes #105 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?
