### PR TITLE
[fix] #115 첨부파일 및 이미지 태그 수정

### DIFF
--- a/docs/delete-chatRoom-order.md
+++ b/docs/delete-chatRoom-order.md
@@ -1,2 +1,13 @@
+# 채팅 관련 데이터 삭제 가이드
 1. 해당 채팅방 id를 참조하고 있는 모든 메시지, 참여자의 데이터를 먼저 지운다.
 2. 해당 채팅방을 지운다
+
+```
+select * from chat_message;
+select * from chat_participant;
+select * from chat_room;
+
+delete from chat_message where id in (1, 2, 3,  4, 5);
+delete from chat_participant where id in (1, 2, 3,  4, 5);
+delete from chat_room where id in (1, 2, 3,  4, 5);
+```

--- a/frontend/src/components/ClassCard.tsx
+++ b/frontend/src/components/ClassCard.tsx
@@ -3,7 +3,7 @@ import { Star } from 'lucide-react';
 import { ClassItem, CATEGORIES } from '@/src/constants';
 import { motion } from 'motion/react';
 import { Link } from 'react-router-dom';
-
+import SafeImage from '../components/SafeImage';
 interface ClassCardProps {
   item: ClassItem;
 }
@@ -18,7 +18,7 @@ const ClassCard: React.FC<ClassCardProps> = ({ item }) => {
     >
       <Link to={`/class/${item.id}`}>
         <div className="relative aspect-[4/3] overflow-hidden">
-          <img
+          <SafeImage
             src={item.image}
             alt={item.title}
             className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-500"

--- a/frontend/src/components/SafeImage.tsx
+++ b/frontend/src/components/SafeImage.tsx
@@ -3,49 +3,69 @@ import React, { useState } from 'react';
 /**
  * 🖼️ 이미지 로드 실패 시 자동으로 '이미지 없음' 대체 이미지를 표시하는 공통 컴포넌트
  *
- * 사용 방법 (img 태그를 SafeImage로 교체):
+ * ✅ img 태그의 모든 속성(className, style, onClick, referrerPolicy 등)을 그대로 사용 가능합니다.
+ *    React.ImgHTMLAttributes<HTMLImageElement>를 상속하기 때문입니다.
  *
- *   // 기존
- *   <img src={fileUrl} alt="프로필" className="w-16 h-16 rounded-xl" />
- *
- *   // 변경
+ * 사용 예:
  *   <SafeImage src={fileUrl} alt="프로필" className="w-16 h-16 rounded-xl" />
+ *   <SafeImage src={imgUrl} alt="포트폴리오" className="w-full" referrerPolicy="no-referrer" />
+ *   <SafeImage src={url} alt="이미지" fallback="/custom-fallback.png" />
  *
- * 어떤 경우에 대체 이미지가 표시되나요?
- * - 파일 서버(D:\fileDownLoadServer\)에 실제 파일이 없을 때
- * - 네트워크 오류로 이미지를 받아오지 못할 때
- * - fileUrl이 null / undefined / 빈 문자열일 때
- * - 서버에서 404 / 500 응답을 받을 때
- *
- * 대체 이미지 경로: /no-image.svg (frontend/public/no-image.svg)
+ * 콘솔 에러 억제 전략:
+ * - src가 null/빈 문자열 → 요청 자체를 보내지 않고 바로 fallback 표시 → 에러 없음
+ * - 404/네트워크 에러 → onError에서 fallback으로 교체 + errored 플래그로 무한 루프 방지
  */
 
 const NO_IMAGE = '/no-image.svg';
 
-interface SafeImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+/**
+ * SafeImageProps
+ *
+ * React.ImgHTMLAttributes<HTMLImageElement>를 그대로 상속하므로
+ * className, style, onClick, referrerPolicy 등 img의 모든 속성을 사용할 수 있습니다.
+ *
+ * 추가 전용 props:
+ * - fallback    : 이미지 로드 실패 시 표시할 대체 이미지 경로 (기본: /no-image.svg)
+ * - warnOnError : true면 로드 실패 시 console.warn 출력 (기본: false — 완전 무음)
+ *
+ * 주의: src는 null을 허용합니다. alt는 필수입니다.
+ */
+type SafeImageProps = Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'src'> & {
   src?: string | null;
   alt: string;
-  fallback?: string; // 기본값: /no-image.svg — 특정 화면에서 다른 이미지로 바꾸고 싶을 때 사용
-}
+  fallback?: string;
+  warnOnError?: boolean;
+};
 
 export default function SafeImage({
   src,
   alt,
   fallback = NO_IMAGE,
+  warnOnError = false,
   onError,
-  ...props
+  ...rest  // className, style, onClick, referrerPolicy 등 img의 모든 나머지 속성
 }: SafeImageProps) {
-  // 이미 한 번 에러가 나면 무한 루프 방지를 위해 fallback으로 고정
+
   const [errored, setErrored] = useState(false);
 
-  // src가 없거나 빈 문자열이면 바로 fallback 표시
+  // src가 없거나 빈 문자열이면 요청 자체를 보내지 않고 바로 fallback 표시
+  // → 브라우저가 404 요청을 보내지 않아 콘솔 에러가 생기지 않음
   const imgSrc = !src || src.trim() === '' ? fallback : errored ? fallback : src;
 
   const handleError = (e: React.SyntheticEvent<HTMLImageElement>) => {
     if (!errored) {
-      setErrored(true); // 한 번만 처리 (fallback도 실패할 경우 무한 루프 방지)
+      setErrored(true);
+
+      if (warnOnError) {
+        console.warn(`[SafeImage] 이미지 로드 실패: ${src}`);
+      }
+
+      // React state 업데이트 전 깜빡임 방지 — DOM을 직접 바꿔서 즉시 교체
+      e.currentTarget.src = fallback;
     }
-    onError?.(e); // 부모에서 onError를 추가로 처리하고 싶을 때 위임
+
+    // 부모에서 onError를 추가로 처리하고 싶을 때 위임
+    onError?.(e);
   };
 
   return (
@@ -53,7 +73,7 @@ export default function SafeImage({
       src={imgSrc}
       alt={alt}
       onError={handleError}
-      {...props}
+      {...rest}
     />
   );
 }

--- a/src/main/java/com/ilsamcheonri/hobby/controller/FileController.java
+++ b/src/main/java/com/ilsamcheonri/hobby/controller/FileController.java
@@ -4,8 +4,10 @@ import com.ilsamcheonri.hobby.dto.file.FileUploadResponse;
 import com.ilsamcheonri.hobby.enums.FileTargetType;
 import com.ilsamcheonri.hobby.service.FileService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -133,8 +135,13 @@ public class FileController {
     // ✅ 파일 다운로드
     // GET /api/files/download/{savedFileName}
     //
-    // 파일이 없으면 500 대신 404를 반환합니다.
-    // 프론트에서 onError로 기본 이미지 처리를 권장합니다.
+    // 파일이 없으면 404 대신 no-image.svg를 200으로 반환합니다.
+    //
+    // 왜 404 대신 200으로 반환하나요?
+    // - 브라우저는 <img> 태그가 404를 받으면 콘솔에 빨간 에러를 자동으로 출력합니다.
+    // - JavaScript(onError 핸들러)로는 이 콘솔 에러를 막을 수 없습니다.
+    // - 파일이 없을 때 no-image.svg를 200으로 내려주면 브라우저 입장에서 성공이므로
+    //   콘솔 에러가 전혀 생기지 않습니다.
     // =========================================================
     @GetMapping("/download/{savedFileName}")
     public ResponseEntity<Resource> download(
@@ -147,17 +154,57 @@ public class FileController {
             String encodedFileName = URLEncoder.encode(savedFileName, StandardCharsets.UTF_8)
                     .replace("+", "%20");
 
+            // 파일 확장자로 Content-Type 결정
+            MediaType mediaType = resolveMediaType(savedFileName);
+
             return ResponseEntity.ok()
                     .header(HttpHeaders.CONTENT_DISPOSITION,
-                            "attachment; filename=\"" + encodedFileName + "\"")
+                            "inline; filename=\"" + encodedFileName + "\"")
+                    .contentType(mediaType)
                     .body(resource);
 
         } catch (IllegalArgumentException e) {
-            // 파일이 없는 경우 404 응답
-            return ResponseEntity.notFound().build();
+            // 파일이 없는 경우 → 404 대신 no-image.svg를 200으로 반환
+            // → 브라우저가 성공으로 인식하므로 콘솔에 빨간 에러가 쌓이지 않음
+            return noImageResponse();
+
         } catch (SecurityException e) {
-            // 잘못된 경로 접근 시 400 응답
-            return ResponseEntity.badRequest().build();
+            // 잘못된 경로 접근 시에도 no-image.svg 반환
+            return noImageResponse();
         }
+    }
+
+    /**
+     * 파일이 없을 때 no-image.svg를 200으로 반환합니다.
+     * static/no-image.svg 를 classpath에서 읽어서 응답합니다.
+     */
+    private ResponseEntity<Resource> noImageResponse() {
+        try {
+            // frontend/public/no-image.svg를 Spring Boot static 리소스로도 서빙하기 위해
+            // src/main/resources/static/no-image.svg 에 복사해두면 classpath에서 읽을 수 있습니다.
+            Resource noImage = new ClassPathResource("static/no-image.svg");
+            if (noImage.exists()) {
+                return ResponseEntity.ok()
+                        .contentType(MediaType.parseMediaType("image/svg+xml"))
+                        .body(noImage);
+            }
+        } catch (Exception ignored) { }
+
+        // static/no-image.svg도 없으면 204 No Content (빈 응답) — 콘솔 에러 없음
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 파일 확장자로 Content-Type을 결정합니다.
+     * 브라우저가 이미지를 인라인으로 올바르게 표시하기 위해 필요합니다.
+     */
+    private MediaType resolveMediaType(String fileName) {
+        String lower = fileName.toLowerCase();
+        if (lower.endsWith(".png"))  return MediaType.IMAGE_PNG;
+        if (lower.endsWith(".gif"))  return MediaType.IMAGE_GIF;
+        if (lower.endsWith(".svg"))  return MediaType.parseMediaType("image/svg+xml");
+        if (lower.endsWith(".webp")) return MediaType.parseMediaType("image/webp");
+        // jpg, jpeg 및 기타 → 기본 image/jpeg
+        return MediaType.IMAGE_JPEG;
     }
 }

--- a/src/main/resources/static/no-image.svg
+++ b/src/main/resources/static/no-image.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <!-- 배경 -->
+  <rect width="400" height="300" rx="16" fill="#F5F0EB"/>
+
+  <!-- 사진 프레임 아이콘 -->
+  <rect x="140" y="90" width="120" height="90" rx="10" fill="none" stroke="#C8BDB5" stroke-width="4"/>
+
+  <!-- 산 모양 -->
+  <polyline points="148,168 172,138 192,158 212,130 252,168"
+            fill="none" stroke="#C8BDB5" stroke-width="4"
+            stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- 태양 원 -->
+  <circle cx="220" cy="112" r="9" fill="none" stroke="#C8BDB5" stroke-width="4"/>
+
+  <!-- 사선 (이미지 없음 표시) -->
+  <line x1="148" y1="88" x2="252" y2="182"
+        stroke="#C8BDB5" stroke-width="3.5"
+        stroke-linecap="round" opacity="0.7"/>
+
+  <!-- 텍스트 -->
+  <text x="200" y="215"
+        font-family="'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif"
+        font-size="14" font-weight="600"
+        fill="#B0A49C" text-anchor="middle">
+    이미지 없음
+  </text>
+</svg>


### PR DESCRIPTION
SafeImage 및 FileController 수정

## 🔎 What

- SafeImage.tsx - img 태그에서 사용하는 모든 속성들을 이용할 수 있도록 수정
- FileController.java - 파일이 없을 때 no-image.svg를 200으로 반환, 파일 확장자로 Content-Type을 결정

## 🔗 Issue

- Closes #115 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?
