### PR TITLE
[fix] 클래스 목업 이미지(이미지 미첨부 시 자동으로 뜸) 삭제, 로고 이미지 띄우기

### DIFF
--- a/frontend/src/context/ClassContext.tsx
+++ b/frontend/src/context/ClassContext.tsx
@@ -76,7 +76,7 @@ function toClassItem(api: ClassApiResponse): ClassItem {
     const isOnline = api.isOnline ?? (api as { online?: boolean }).online ?? false;
     const imageUrls = getImageUrls(api);
     const representativeImage =
-        api.representativeImageUrl || imageUrls[0] || `https://picsum.photos/seed/class${api.id}/400/300`;
+        api.representativeImageUrl || imageUrls[0] || '/pogeun.png';
 
     return {
         id: String(api.id),

--- a/frontend/src/pages/ClassDetail.tsx
+++ b/frontend/src/pages/ClassDetail.tsx
@@ -151,7 +151,7 @@ export default function ClassDetail() {
                     freelancerId: String(apiClass.freelancerId),
                     price: apiClass.price,
                     category: apiClass.categoryName,
-                    image: apiClass.representativeImageUrl || detailImages[0] || `https://picsum.photos/seed/class${apiClass.id}/400/300`,
+                    image: apiClass.representativeImageUrl || detailImages[0] || '/pogeun.png',
                     rating: apiClass.rating ?? 0,
                     reviews: apiClass.reviews ?? 0,
                     isOffline: !apiClass.isOnline,

--- a/frontend/src/pages/FreelancerProfilePage.tsx
+++ b/frontend/src/pages/FreelancerProfilePage.tsx
@@ -132,7 +132,7 @@ export default function FreelancerProfilePage() {
   const mapProfileClassToClassItem = (classItem: FreelancerProfileClass): ClassItem => {
     const imageUrl = classItem.representativeImageUrl
       || classItem.attachments?.find((attachment) => !!attachment.fileUrl)?.fileUrl
-      || `https://picsum.photos/seed/class${classItem.id}/400/300`;
+      || '/pogeun.png';
 
     return {
       id: String(classItem.id),


### PR DESCRIPTION
## 🔎 What

- 클래스 목업 이미지(이미지 미첨부 시 자동으로 뜸) 삭제, 로고 이미지 띄우기

## 🔗 Issue

- Closes #144 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?
