### PR TITLE
[Bug] 클래스 등록 시, 종료시간이 시작시간보다 빠른 날짜가 되지 않게 하기

### DIFF
--- a/frontend/src/components/DatePicker.tsx
+++ b/frontend/src/components/DatePicker.tsx
@@ -11,6 +11,7 @@ type DatePickerProps = {
   placeholder?: string;
   disabled?: boolean;
   disableFuture?: boolean;
+  minDate?: string;
   placement?: 'top' | 'bottom';
   panelClassName?: string;
   className?: string;
@@ -82,6 +83,7 @@ export default function DatePicker({
   placeholder = '날짜를 선택해주세요',
   disabled = false,
   disableFuture = false,
+  minDate,
   placement = 'bottom',
   panelClassName,
   className,
@@ -89,6 +91,7 @@ export default function DatePicker({
   const [isOpen, setIsOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
   const selectedDate = useMemo(() => parseDateValue(value), [value]);
+  const minSelectableDate = useMemo(() => parseDateValue(minDate ?? ''), [minDate]);
   const [viewMonth, setViewMonth] = useState<Date | undefined>(selectedDate);
 
   useEffect(() => {
@@ -153,9 +156,12 @@ export default function DatePicker({
             }}
             showOutsideDays
             captionLayout="dropdown"
-            startMonth={new Date(1950, 0)}
+            startMonth={minSelectableDate ?? new Date(1950, 0)}
             endMonth={disableFuture ? new Date() : new Date(2100, 11)}
-            disabled={disableFuture ? { after: new Date() } : undefined}
+            disabled={{
+              ...(disableFuture ? { after: new Date() } : {}),
+              ...(minSelectableDate ? { before: minSelectableDate } : {}),
+            }}
             classNames={{
               root: 'w-full',
               months: 'flex justify-center',

--- a/frontend/src/pages/ClassFormPage.tsx
+++ b/frontend/src/pages/ClassFormPage.tsx
@@ -7,6 +7,7 @@ import { useCategories } from '../context/CategoryContext';
 import { useAuth } from '../context/AuthContext';
 import { cn } from '@/src/lib/utils';
 import apiClient from '../api/axios';
+import DatePicker from '@/src/components/DatePicker';
 
 type EditableImageItem = {
   id: number | null;
@@ -428,25 +429,23 @@ export default function ClassFormPage() {
                 <label className="text-sm font-bold text-gray-700 ml-1 flex items-center gap-1">
                   <Calendar size={14} /> 시작일
                 </label>
-                <input 
-                  type="date" 
-                  required
+                <DatePicker
                   value={startDate}
-                  onChange={(e) => setStartDate(e.target.value)}
-                  className="w-full px-6 py-4 bg-ivory rounded-2xl border-2 border-transparent focus:border-coral outline-none transition-all"
+                  onChange={setStartDate}
+                  placeholder="시작일을 선택해주세요"
+                  className="w-full"
                 />
               </div>
               <div className="space-y-2">
                 <label className="text-sm font-bold text-gray-700 ml-1 flex items-center gap-1">
                   <Calendar size={14} /> 종료일
                 </label>
-                <input 
-                  type="date" 
-                  required
+                <DatePicker
                   value={endDate}
-                  min={startDate || undefined}
-                  onChange={(e) => setEndDate(e.target.value)}
-                  className="w-full px-6 py-4 bg-ivory rounded-2xl border-2 border-transparent focus:border-coral outline-none transition-all"
+                  onChange={setEndDate}
+                  placeholder="종료일을 선택해주세요"
+                  minDate={startDate}
+                  className="w-full"
                 />
               </div>
             </div>

--- a/frontend/src/pages/ClassFormPage.tsx
+++ b/frontend/src/pages/ClassFormPage.tsx
@@ -218,6 +218,11 @@ export default function ClassFormPage() {
       return;
     }
 
+    if (startDate && endDate && endDate < startDate) {
+      setToast('종료일은 시작일보다 빠를 수 없습니다.');
+      return;
+    }
+
     if (!isLoggedIn) {
       setToast('로그인 후 클래스 등록이 가능합니다.');
       setTimeout(() => navigate('/login'), 1500);
@@ -439,6 +444,7 @@ export default function ClassFormPage() {
                   type="date" 
                   required
                   value={endDate}
+                  min={startDate || undefined}
                   onChange={(e) => setEndDate(e.target.value)}
                   className="w-full px-6 py-4 bg-ivory rounded-2xl border-2 border-transparent focus:border-coral outline-none transition-all"
                 />


### PR DESCRIPTION
## 🔎 What

- 클래스 등록 시, 종료시간이 시작시간보다 빠른 날짜가 되지 않게 하기
- 회원가입 페이지의 달력 디자인이랑 통일

## 🔗 Issue

- Closes  #137

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?
